### PR TITLE
Add initial support for configuring visual sample entry, fragment type and duration

### DIFF
--- a/Test Content Generation.md
+++ b/Test Content Generation.md
@@ -30,7 +30,7 @@ All the steps are provided in the encode_dash.py script. The process flow is as 
         * __bitrate:__ encoding bitrate for the media in kbits/s
         * __cmaf:__ cmaf profile that is desired. Supported ones are avcsd, avchd, avchdhf (taken from 23000-19 A.1)
         * vse: visual sample entry. Supported video sample entries for AVC are "avc1" and "avc3" and for HEVC "hev1" and "hvc1"
-		* res: resolution width and resolution height provided as “wxh”
+        * res: resolution width and resolution height provided as “wxh”
         * fps: frame rate
         * sar: aspect ratio provided as “x/y”
         * profile: codec profile (such as high, baseline, main, etc.)
@@ -42,8 +42,8 @@ All the steps are provided in the encode_dash.py script. The process flow is as 
     * *<*config_parameter*>* can be:
         * sd: Segment duration
         * ss: Segment signaling. Can be either “template” for SegmentTemplate or “timeline” for SegmentTimeline
-		* ft: Fragment type. Can be either "none", "duration", "pframes" or "every_frame"
-		* fd: Fragment duration
+        * ft: Fragment type. Can be either "none", "duration", "pframes" or "every_frame"
+        * fd: Fragment duration
     * It is defaulted to segment duration of 2 seconds and segment signaling of SegmentTimeline. If parameters are provided, these override the default settings.
 * Content is generated.
     * Using the FFMpeg path, formed encoding and DASHing command portions and the output MPD file name, a single line FFMPEG command is formed and executed.

--- a/Test Content Generation.md
+++ b/Test Content Generation.md
@@ -29,7 +29,8 @@ All the steps are provided in the encode_dash.py script. The process flow is as 
         * __codec:__ codec value for the media. Can be “h264”, “h265” or “aac”
         * __bitrate:__ encoding bitrate for the media in kbits/s
         * __cmaf:__ cmaf profile that is desired. Supported ones are avcsd, avchd, avchdhf (taken from 23000-19 A.1)
-        * res: resolution width and resolution height provided as “wxh”
+        * vse: visual sample entry. Supported video sample entries for AVC are "avc1" and "avc3" and for HEVC "hev1" and "hvc1"
+		* res: resolution width and resolution height provided as “wxh”
         * fps: frame rate
         * sar: aspect ratio provided as “x/y”
         * profile: codec profile (such as high, baseline, main, etc.)
@@ -39,8 +40,10 @@ All the steps are provided in the encode_dash.py script. The process flow is as 
 * DASH class is used to form the DASHing portion of the overall ffmpeg command for all the representation configurations
     * dash_config=*<*config_parameter_1*>*:*<*config_parameter_value_1*>*,*<*config_parameter_2*>*:*<*config_parameter_value_2*>*
     * *<*config_parameter*>* can be:
-        * d: Segment duration
-        * s: Segment signaling. Can be either “template” for SegmentTemplate or “timeline” for SegmentTimeline
+        * sd: Segment duration
+        * ss: Segment signaling. Can be either “template” for SegmentTemplate or “timeline” for SegmentTimeline
+		* ft: Fragment type. Can be either "none", "duration", "pframes" or "every_frame"
+		* fd: Fragment duration
     * It is defaulted to segment duration of 2 seconds and segment signaling of SegmentTimeline. If parameters are provided, these override the default settings.
 * Content is generated.
     * Using the FFMpeg path, formed encoding and DASHing command portions and the output MPD file name, a single line FFMPEG command is formed and executed.

--- a/encode_dash.py
+++ b/encode_dash.py
@@ -243,6 +243,8 @@ class DASH:
 
         if self.m_fragment_type == "duration":
             dash_command += "-frag_type duration -frag_duration " + self.m_fragment_duration + " "
+        elif self.m_fragment_type == "every_frame":
+            dash_command += "-frag_type every_frame" + " "
 
         dash_command += "-f dash"
 

--- a/encode_dash.py
+++ b/encode_dash.py
@@ -243,6 +243,8 @@ class DASH:
 
         if self.m_fragment_type == "duration":
             dash_command += "-frag_type duration -frag_duration " + self.m_fragment_duration + " "
+        elif self.m_fragment_type == "pframes":
+            dash_command += "-frag_type pframes" + " "
         elif self.m_fragment_type == "every_frame":
             dash_command += "-frag_type every_frame" + " "
 

--- a/encode_dash.py
+++ b/encode_dash.py
@@ -151,7 +151,7 @@ class AudioCodecOptions(Enum):
 
 
 # Supported visual sample entries
-class VideoSampleEntry(Enum):
+class VisualSampleEntry(Enum):
     AVC1 = "avc1"
     AVC3 = "avc3"
     HVC1 = "hvc1"
@@ -309,8 +309,8 @@ class Representation:
                     sys.exit(1)
                 self.m_codec = value
             elif name == "vse":
-                if value != VideoSampleEntry.AVC1.value and value != VideoSampleEntry.AVC3.value and \
-                   value != VideoSampleEntry.HEV1.value and value != VideoSampleEntry.HVC1.value:
+                if value != VisualSampleEntry.AVC1.value and value != VisualSampleEntry.AVC3.value and \
+                   value != VisualSampleEntry.HEV1.value and value != VisualSampleEntry.HVC1.value:
                     print("Supported video sample entries for AVC are \"avc1\" and \"avc3\" and"
                           " for HEVC \"hev1\" and \"hvc1\".")
                     sys.exit(1)


### PR DESCRIPTION
This adds initial support for configuring the following: 
- visual sample entry, 
- fragment type,
- fragment duration.

See `Test Content Generation.md` for the updated parameters.

A few minor fixes were also made due to issues I encountered using Win10 + Python 3.8:
- OS-specific (use of ls and grep) 
- Log file creation (replaced use of ":" in filename with "-", Python script needed to be read as UTF-8) 

This is just a start, review and further work are needed, but the following should generate stream ID1 from [this table](https://github.com/cta-wave/Test-Content-Generation/wiki/AVC-test-streams):
`py encode_dash.py --out="output.mpd" --reps="id:1,type:v,input:tos_L1_1920x1080@60_60.mp4,codec:h264,vse:avc1,bitrate:4000,cmaf:avchd id:2,type:a,input:tos_L1_1920x1080@60_60.mp4,codec:aac,bitrate:64,cmaf:aac" --dash="sd:2,ss:template,ft:duration,fd:2" --path="ffmpeg.exe"`